### PR TITLE
Rotational input module for Characters

### DIFF
--- a/RotationalActivation/CharacterRotationalActivation.cs
+++ b/RotationalActivation/CharacterRotationalActivation.cs
@@ -1,0 +1,99 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using MoreMountains.CorgiEngine;
+using UnityEngine.UIElements;
+
+/// <summary>
+/// Used to measure how a character rotates their analog stick - ideal for operating gears, pulleys, and wheels.
+/// Currently only implemented for use with New Input System
+/// </summary>
+    public class CharacterRotationalActivation : CharacterButtonActivation
+    {
+        //true if character has started rotating their input device.
+        [SerializeField] private float totalRotation = 0f;
+        
+        public bool IsRotating { get; set; }
+        public RotationActivated RotationActivatedZone { get; set; }
+        public bool InRotationActivatedZone { get; set; }
+        private Vector2 _previousDirection;
+        private bool _previouslyActivated;
+        
+        new InputSystemManagerWithRotation _inputManager => (InputSystemManagerWithRotation)(base._inputManager);
+        public override string HelpBoxText()
+        {
+            return "This component allows your character to generate a rotational interaction from Gamepad/Mouse.";
+        }
+
+        protected override void Initialization()
+        {
+            base.Initialization();
+            IsRotating = false;
+            _previouslyActivated = false;
+        }
+
+        protected override void HandleInput()
+        {
+
+            if (InRotationActivatedZone && (RotationActivatedZone != null) && _inputManager.CurrentDirection.sqrMagnitude > 0)
+            {
+                if (_previouslyActivated)
+                {
+                    RotationActivation();
+                }
+                else
+                {
+                    _previouslyActivated = true;
+                    _previousDirection = _inputManager.CurrentDirection;
+                }
+            }
+            else
+            {
+                _previouslyActivated = false;
+            }
+            
+        }
+
+        protected virtual void RotationActivation()
+        {
+            if ((InRotationActivatedZone
+                && RotationActivatedZone != null)
+                && (_condition.CurrentState == CharacterStates.CharacterConditions.Normal)
+                )
+            {
+                if (_inputManager.CurrentDirection.sqrMagnitude > 0)
+                {
+                    MMCharacterEvent.Trigger(_character, MMCharacterEventTypes.ButtonActivation);
+                    
+                    
+                    if (!_previouslyActivated)
+                    {
+                        _previouslyActivated = true;
+                        _previousDirection = _inputManager.CurrentDirection;
+                        return;
+                    }
+
+                    float currentAngleDelta = Quaternion
+                        .FromToRotation(_inputManager.CurrentDirection, _previousDirection).eulerAngles.z;
+                    if (currentAngleDelta > 180)
+                    {
+                        currentAngleDelta -= 360;
+                    }
+
+                    totalRotation += currentAngleDelta;
+                    _previousDirection = _inputManager.CurrentDirection;
+                    RotationActivatedZone.TriggerRotationAction(this.gameObject, currentAngleDelta);
+                }
+                else
+                {
+                    _previouslyActivated = false;
+                }
+            }
+        }
+        
+        
+
+
+
+
+    }

--- a/RotationalActivation/InputActionsWithRotation.inputactions
+++ b/RotationalActivation/InputActionsWithRotation.inputactions
@@ -1,0 +1,855 @@
+{
+    "name": "MineBuddiesInputActions",
+    "maps": [
+        {
+            "name": "PlayerControls",
+            "id": "aa0e1094-3ae9-4de6-877e-1fa7a26edd69",
+            "actions": [
+                {
+                    "name": "PrimaryMovement",
+                    "type": "PassThrough",
+                    "id": "265ae792-b274-4758-9c3f-67c2f395c758",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "314ace32-fb21-4bab-a569-ebe4e48f2102",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Swim",
+                    "type": "Button",
+                    "id": "bb397b32-8d84-4aad-9fe6-92d359b0a49b",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Glide",
+                    "type": "Button",
+                    "id": "44f9f9bc-9a87-4ef7-9677-7acb02f39e5d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Jetpack",
+                    "type": "Button",
+                    "id": "0daa39dc-3d97-4c43-98ea-dfa4a4a5104e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Fly",
+                    "type": "Button",
+                    "id": "639199aa-bfdd-452d-9f7d-9476e5d54951",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Throw",
+                    "type": "Button",
+                    "id": "9868b1c7-76ad-40fd-a811-5e8dcbacf8d6",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Push",
+                    "type": "Button",
+                    "id": "f30d79d2-3ec6-4f11-8178-6bb248125162",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Grab",
+                    "type": "Button",
+                    "id": "d65c765f-b4fa-4999-b444-f89d2170ebbf",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Run",
+                    "type": "Button",
+                    "id": "6b5c4b16-7607-4f0a-ad5b-62efd798065d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Dash",
+                    "type": "Button",
+                    "id": "56a37787-c3be-4789-a219-0509391dc113",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Shoot",
+                    "type": "Button",
+                    "id": "7016cc32-6ee0-4d53-b08c-02cbe6eb2c0e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SecondaryShoot",
+                    "type": "Button",
+                    "id": "1b70a5ec-5da5-42ce-a7c0-8f54ff84052f",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Interact",
+                    "type": "Button",
+                    "id": "ae461515-11b0-4cc9-b221-92ed2df4118e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Cancel",
+                    "type": "Button",
+                    "id": "5a6ee3de-2c67-45aa-b70b-690f7b247fbd",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Reload",
+                    "type": "Button",
+                    "id": "cf90ff3a-006b-4ae6-9594-cc2189d6f5f0",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Pause",
+                    "type": "Button",
+                    "id": "c01ffcc5-adff-4aa3-bb8d-e0139087e5ed",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SwitchWeapon",
+                    "type": "Button",
+                    "id": "6e3febaf-dba5-4b43-b4f8-3b720e7ad1be",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SwitchCharacter",
+                    "type": "Button",
+                    "id": "cde4a43f-3a08-47c8-afdf-2c5dca8d1241",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "TimeControl",
+                    "type": "Button",
+                    "id": "c71e92f2-77ca-4de6-98ad-64b961ed706e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Roll",
+                    "type": "Button",
+                    "id": "f1006ee4-eeee-4d84-b426-0c1b853bd7b5",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RotationalMovement",
+                    "type": "Value",
+                    "id": "bd84639e-4907-4a77-8350-8fc83b3f33dd",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "WASD",
+                    "id": "ae9b37c8-3b37-4a3c-92de-a883c1eaec34",
+                    "path": "2DVector(mode=2)",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PrimaryMovement",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "2e66d043-6153-419e-932e-0bbd8ef8df6b",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "PrimaryMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "f1c785e7-a3bf-4f5c-9d5a-2302a0b10975",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "PrimaryMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "36b9b939-b3ed-40a9-a305-7ed3251f5a9b",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "PrimaryMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "d7bfdd17-5246-4bde-aa16-bcb3ea0467a1",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "PrimaryMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "157de9f0-00a9-4767-9eca-18eb35914def",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "PrimaryMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8923c29f-eb06-45a4-9c25-5ed809d8fea2",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f7f8488a-fd5a-4098-8088-d75677e01b98",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "718dcfd4-5383-4a9f-bab4-92688fd5d743",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Run",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "385119bf-31ce-4c23-8780-028608d0481c",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Run",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d6b36ab1-5730-4ee6-934d-0da3fd9ad3c7",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Dash",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "44ef3905-a71f-42e8-b234-953799ede87d",
+                    "path": "<Keyboard>/f",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Dash",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c74dc322-5120-478a-af7a-0d716b64cfc1",
+                    "path": "<Keyboard>/e",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Shoot",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "202fe3e6-b8da-4f61-9aa9-faaad6af7ebb",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Shoot",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f112453b-6f03-459b-a23e-70f29feb18bf",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Shoot",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "63bf589f-5ef3-4931-bb6e-63038c725e66",
+                    "path": "<Keyboard>/leftAlt",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "SecondaryShoot",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "70b57a6b-cd02-4751-90a1-9027a8ed50f0",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c93a01d5-38f1-43b3-9711-d66667df202e",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5149bd3a-469e-4f0d-bb3b-1f08823c3acd",
+                    "path": "<Keyboard>/r",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Reload",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "dd9bdaac-271a-4f2a-bdd2-7e6718d1c076",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Reload",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "17af30da-1784-4cae-a214-838b1bc78a38",
+                    "path": "<Gamepad>/start",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0edbe9a3-9973-478d-b677-437ae7b60275",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4c3ea5cb-6737-4947-ba0f-12fe1143e541",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "SwitchWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "31347280-3484-4765-8820-ab0871c9d6ad",
+                    "path": "<Keyboard>/t",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "SwitchWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5a170d0f-bc8a-4a8d-a2d3-31939a85f104",
+                    "path": "<Keyboard>/p",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "SwitchCharacter",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6fd51ad5-2a26-4828-8ad1-28016fbc2c3d",
+                    "path": "<Keyboard>/k",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "TimeControl",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f7d3e6ec-7190-4a72-81ec-d23f276d6b45",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "TimeControl",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e4614f8e-c09a-4251-a311-72807f90324e",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Swim",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a53a6351-c203-4a94-ae9c-6d53f7736aaa",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Swim",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2ec7a94c-73bf-4232-b32e-bd131d124d5b",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Glide",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "565c301f-a576-4f6e-84d1-fbee839a8ca0",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Glide",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2c254d21-faee-4810-9b1b-5f55e4365beb",
+                    "path": "<Keyboard>/2",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Jetpack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5bdec79f-0005-46e3-95a7-e9e728f0303f",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Jetpack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a65a3042-eb6b-4d3e-b84e-aff7e4adb6b2",
+                    "path": "<Keyboard>/v",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Fly",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "aa3528ae-3f22-41e3-ab8c-8509dcc22f7e",
+                    "path": "<Gamepad>/select",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Fly",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "11fcd333-82b9-4634-a2e3-3ee519f53792",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Grab",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "67f12e56-4fa7-471c-99b6-cebd70a7cccc",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Grab",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d9fae8f2-4551-45fd-a9e6-8a9b1f34964c",
+                    "path": "<Keyboard>/e",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Throw",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "cc62f645-d609-44e3-97ea-4fa8590f4fc4",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Throw",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "934fca02-1df3-4f28-8734-fd87e09e6ccc",
+                    "path": "<Keyboard>/3",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Push",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "25b5884f-a576-4725-a54c-15a48c075580",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Push",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "af734551-2514-4a27-8b3e-be56fcdde29d",
+                    "path": "<Keyboard>/g",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Roll",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "cc7e5c8c-1928-48ba-9214-c8aa4185519d",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "aa15b8b4-54fc-42a7-83b1-ccf00656fb09",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "90391148-6d1a-472f-80eb-39e39ff27b2a",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "NormalizeVector2",
+                    "groups": "Gamepad",
+                    "action": "RotationalMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "TFGH",
+                    "id": "eda0eb02-739d-4815-a0e5-537c59c3091f",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RotationalMovement",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "b90f2396-d7c1-4e17-991d-c9fa679fb12f",
+                    "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "RotationalMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "6c069739-6327-4801-b056-b2ca2f9cefc4",
+                    "path": "<Keyboard>/g",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "RotationalMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "6040d223-ed10-4fc7-a750-b1c72901cebb",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "RotationalMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "30a1302f-5172-4a11-b8eb-e80faf983498",
+                    "path": "<Keyboard>/h",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "RotationalMovement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                }
+            ]
+        },
+        {
+            "name": "PlayerJoin",
+            "id": "62b2d67f-ef72-4e89-8b9b-edbfe56727fc",
+            "actions": [
+                {
+                    "name": "Go",
+                    "type": "Button",
+                    "id": "9de1adf4-b758-4741-b3ef-83a5cdced998",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Back",
+                    "type": "Button",
+                    "id": "90c0ed29-1264-4eb0-b640-9f42a4884177",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "cb0f0d2a-c5e7-4a64-a9c9-c2aed67018d5",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Go",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "49328314-1c6b-4df1-a65f-8ae4fb28e464",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Go",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "62ec51c2-8365-45ac-b979-9f8ec85f316b",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Keyboard",
+                    "action": "Back",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0195a7ab-530e-4e55-8c6e-3847bfc7d8e7",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Back",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "Keyboard",
+            "bindingGroup": "Keyboard",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Gamepad",
+            "bindingGroup": "Gamepad",
+            "devices": [
+                {
+                    "devicePath": "<Gamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/RotationalActivation/InputSystemManagerWithRotation.cs
+++ b/RotationalActivation/InputSystemManagerWithRotation.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using MoreMountains.CorgiEngine;
+using MoreMountains.Tools;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InputSystemManagerWithRotation : InputSystemManagerEventsBased
+{
+    public Vector2 CurrentDirection { get; protected set; }
+  
+    private Vector2 _previousDirection;
+    public void OnRotationalMovement(InputValue value)
+    {
+        CurrentDirection = value.Get<Vector2>();
+        
+    }
+    
+    protected override void BindButton(InputValue inputValue, MMInput.IMButton imButton)
+    {
+        if (imButton != null)
+        {
+            base.BindButton(inputValue, imButton);
+        }
+    }
+
+    protected override void Update()
+    {
+        
+    }
+
+}

--- a/RotationalActivation/RotationActivated.cs
+++ b/RotationalActivation/RotationActivated.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Collections.Generic;
+using MoreMountains.CorgiEngine;
+using MoreMountains.Feedbacks;
+using MoreMountains.Tools;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.InputSystem;
+using UnityEngine.PlayerLoop;
+
+/// <summary>
+/// Only works with InputSystem!
+/// This component is activated by rotation input from the player, via CharacterRotationalActivation component.
+/// It can be easily used as a slider or any incremental-type input, since it just receives a float as activation (i.e. how much the player has done).
+/// It is mostly a duplicate of ButtonActivated.
+/// </summary>
+	[MMRequiresConstantRepaint]
+    [RequireComponent(typeof(Collider2D))]
+    public class RotationActivated : MMMonoBehaviour
+    {
+	    public enum RotationType { Clockwise, CounterClockWise, BiDirectional}
+	    public float TotalRotation { get => _totalRotation; protected set => _totalRotation = value; }
+	    
+	    [MMInspectorGroup("Activation", true, 10)]
+	    [Tooltip("Does this control spin in one direction or both")]
+	     
+	    [SerializeField]
+	    public float _totalRotation;
+	    public RotationType rotationType;
+
+	    /// if this is false, the zone won't be activable 
+	    [Tooltip("if this is false, the zone won't be activable ")]
+	    public bool Activable = true;
+	    [Tooltip("if true, the zone will activate whether the button is pressed or not")]
+	    public bool AutoActivation = false;
+	    [Tooltip("if this is true, enter won't be retriggered if another object enters, and exit will only be triggered when the last object exits")]
+	    public bool OnlyOneActivationAtOnce;
+	    /// if true, this zone will be auto activated but will still allow button interaction
+	    [Tooltip("if true, this zone will be auto activated but will still allow button interaction")]
+	    [MMCondition("AutoActivation", true)]
+	    public bool AutoActivationAndButtonInteraction = false;
+	    /// a layermask with all the layers that can interact with this specific button activated zone
+	    [Tooltip("a layermask with all the layers that can interact with this specific button activated zone")]
+	    public LayerMask TargetLayerMask = ~0;
+
+	    
+        [MMInspectorGroup("Animation", true, 14)]
+
+		/// an (absolutely optional) animation parameter that can be triggered on the character when activating the zone
+		[Tooltip("an (absolutely optional) animation parameter that can be triggered on the character when activating the zone")]
+		public string AnimationTriggerParameterName;
+
+		[MMInspectorGroup("Visual Prompt", true, 15)]
+		[MMInformation("You can have this zone show a visual prompt to indicate to the player that it's interactable.", MoreMountains.Tools.MMInformationAttribute.InformationType.Info, false)]
+
+		///TODO edit the prompt UI for RotationActivated device
+
+		[Tooltip("if this is true, a prompt will be shown if setup properly")]
+		public bool UseVisualPrompt = true;
+		/// the gameobject to instantiate to present the prompt
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("the gameobject to instantiate to present the prompt")]
+		public ButtonPrompt ButtonPromptPrefab;
+		/// the text to display in the button prompt
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("the text to display in the button prompt")]
+		public string ButtonPromptText = "A";
+		/// the text to display in the button prompt
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("the text to display in the button prompt")]
+		public Color ButtonPromptColor = MMColors.LawnGreen;
+		/// the color for the prompt's text
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("the color for the prompt's text")]
+		public Color ButtonPromptTextColor = MMColors.White;
+		/// If true, the "buttonA" prompt will always be shown, whether the player is in the zone or not.
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("If true, the 'buttonA' prompt will always be shown, whether the player is in the zone or not.")]
+		public bool AlwaysShowPrompt = true;
+		/// If true, the "buttonA" prompt will be shown when a player is colliding with the zone
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("If true, the 'buttonA' prompt will be shown when a player is colliding with the zone")]
+		public bool ShowPromptWhenColliding = true;
+		/// If true, the prompt will hide after use
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("If true, the prompt will hide after use")]
+		public bool HidePromptAfterUse = false;
+		/// the position of the actual buttonA prompt relative to the object's center
+		[MMCondition("UseVisualPrompt", true)]
+		[Tooltip("the position of the actual buttonA prompt relative to the object's center")]
+		public Vector3 PromptRelativePosition = Vector3.zero;
+
+		[MMInspectorGroup("Feedbacks", true, 16)]
+
+		/// a feedback to play when the zone gets activated
+		[Tooltip("a feedback to play when the zone gets activated")]
+		public MMFeedbacks ActivationFeedback;
+		/// a feedback to play when the zone tries to get activated but can't
+		[Tooltip("a feedback to play when the zone tries to get activated but can't")]
+		public MMFeedbacks DeniedFeedback;
+		/// a feedback to play when the zone gets entered
+		[Tooltip("a feedback to play when the zone gets entered")]
+		public MMFeedbacks EnterFeedback;
+		/// a feedback to play when the zone gets exited
+		[Tooltip("a feedback to play when the zone gets exited")]
+		public MMFeedbacks ExitFeedback;
+
+		[MMInspectorGroup("Actions", true, 17)]
+
+		/// an action to trigger when this gets activated
+		[Tooltip("an action to trigger when this gets activated")]
+		public UnityEvent<float, float> OnActivation;
+		/// an action to trigger when exiting this zone
+		[Tooltip("an action to trigger when exiting this zone")]
+		public UnityEvent OnExit;
+		/// an action to trigger when staying in the zone
+		[Tooltip("an action to trigger when staying in the zone")]
+		public UnityEvent OnStay;
+
+		
+		protected Animator _rotationPromptAnimator;
+		//TODO: replace ButtonPrompt class with appropriate rotational class.
+		protected ButtonPrompt _rotationPrompt;
+		protected bool _promptHiddenForever = false;
+		protected float _lastActivationTimestamp;
+		protected Collider2D _rotationActivatedZoneCollider;
+		
+		
+		protected CharacterRotationalActivation _characterRotationalActivation;
+		protected Character _currentCharacter;
+
+		protected List<GameObject> _collidingObjects;
+		protected List<GameObject> _stayingGameObjects;
+		protected List<Collider2D> _enteredColliders;
+
+
+		protected virtual void OnEnable()
+		{
+			Initialization();
+		}
+
+		public virtual void Initialization()
+		{
+			_collidingObjects = new List<GameObject>();
+			_enteredColliders = new List<Collider2D>();
+			_stayingGameObjects = new List<GameObject>();
+			_rotationActivatedZoneCollider = this.gameObject.GetComponent<Collider2D>();
+
+			if (AlwaysShowPrompt)
+			{
+				ShowPrompt();
+			}
+
+			ActivationFeedback?.Initialization(this.gameObject);
+			DeniedFeedback?.Initialization(this.gameObject);
+			EnterFeedback?.Initialization(this.gameObject);
+			ExitFeedback?.Initialization(this.gameObject);
+			
+			
+		}
+		
+		/// <summary>
+		/// Makes the zone activable
+		/// </summary>
+		public virtual void MakeActivable()
+		{
+			Activable = true;
+		}
+
+		/// <summary>
+		/// Makes the zone unactivable
+		/// </summary>
+		public virtual void MakeUnactivable()
+		{
+			Activable = false;
+		}
+		
+		/// <summary>
+		/// Makes the zone activable if it wasn't, unactivable if it was activable.
+		/// </summary>
+		public virtual void ToggleActivable()
+		{
+			Activable = !Activable;
+		}
+		
+	
+		/// <summary>
+		/// When the input button is pressed, we check whether or not the zone can be activated, and if yes, trigger ZoneActivated
+		/// </summary>
+		public virtual void TriggerRotationAction(GameObject instigator, float angle)
+		{
+			if (!Activable)
+			{
+				PromptError();
+				return;
+			}
+
+			_stayingGameObjects.Add(instigator);
+			ActivateZone(angle);
+		}
+
+		
+		/// <summary>
+		/// On exit, we reset our staying bool and invoke our OnExit event
+		/// </summary>
+		/// <param name="collider"></param>
+		public virtual void TriggerExitAction(GameObject collider)
+		{
+			_stayingGameObjects.Remove(collider);
+			if (OnExit != null)
+			{
+				OnExit.Invoke();
+			}
+		}
+		
+		
+		/// <summary>
+		/// Activates the zone
+		/// </summary>
+		protected virtual void ActivateZone(float angle)
+		{
+			float angleDirectional = angle;
+			switch (rotationType)
+			{
+				case(RotationType.Clockwise):
+					angleDirectional = Mathf.Clamp(angle,0,180f);
+					break;
+				case(RotationType.CounterClockWise):
+					angleDirectional = Mathf.Clamp(angle, -180f, 0);
+					break;
+				default:
+					break;
+			}
+
+			TotalRotation += angleDirectional;
+			
+			if (OnActivation != null)
+			{
+				OnActivation.Invoke(angleDirectional, TotalRotation);
+			}
+			_lastActivationTimestamp = Time.time;
+			if (HidePromptAfterUse)
+			{
+				_promptHiddenForever = true;
+				HidePrompt();
+			}
+
+			ActivationFeedback?.PlayFeedbacks(this.transform.position);
+		}
+
+		/// <summary>
+		/// Triggers an error 
+		/// </summary>
+		public virtual void PromptError()
+		{
+			if (_rotationPromptAnimator != null)
+			{
+				_rotationPromptAnimator.SetTrigger("Error");
+			}
+			DeniedFeedback?.PlayFeedbacks(this.transform.position);
+		}
+		
+		/// <summary>
+		/// Shows the button A prompt.
+		/// </summary>
+		public virtual void ShowPrompt()
+		{            
+			if (!UseVisualPrompt || _promptHiddenForever || (ButtonPromptPrefab == null))
+			{
+				return;
+			}
+
+			// we add a blinking A prompt to the top of the zone
+			if (_rotationPrompt == null)
+			{
+				_rotationPrompt = (ButtonPrompt)Instantiate(ButtonPromptPrefab);
+				_rotationPrompt.Initialization();
+				_rotationPromptAnimator = _rotationPrompt.gameObject.MMGetComponentNoAlloc<Animator>();
+			}
+
+			if (_rotationActivatedZoneCollider != null)
+			{
+				_rotationPrompt.transform.position = _rotationActivatedZoneCollider.bounds.center + PromptRelativePosition;
+			}
+			_rotationPrompt.transform.parent = transform;
+			_rotationPrompt.SetText(ButtonPromptText);
+			_rotationPrompt.SetBackgroundColor(ButtonPromptColor);
+			_rotationPrompt.SetTextColor(ButtonPromptTextColor);
+			_rotationPrompt.Show();
+		}
+		
+		/// <summary>
+		/// Hides the button A prompt.
+		/// </summary>
+		public virtual void HidePrompt()
+		{
+			if ((_rotationPrompt != null) && (_rotationPrompt.isActiveAndEnabled))
+			{
+				_rotationPrompt.Hide();
+			}            
+		}
+		
+		/// <summary>
+		/// Enables the button activated zone
+		/// </summary>
+		public virtual void DisableZone()
+		{
+			Activable = false;
+			_rotationActivatedZoneCollider.enabled = false;
+			if (_characterRotationalActivation != null)
+			{
+				_characterRotationalActivation.InRotationActivatedZone = false;
+				_characterRotationalActivation.RotationActivatedZone = null;
+			}
+		}
+		
+		/// <summary>
+		/// Handles enter collision with 2D triggers
+		/// </summary>
+		/// <param name="collidingObject">Colliding object.</param>
+		protected virtual void OnTriggerEnter2D(Collider2D collidingObject)
+		{
+			_enteredColliders.Add(collidingObject);
+			TriggerEnter(collidingObject.gameObject);
+		}
+		
+		
+		
+		/// <summary>
+		/// On stay we invoke our stay event if needed, and perform a trigger enter check if it hasn't been done already
+		/// </summary>
+		/// <param name="collidingObject"></param>
+		protected virtual void OnTriggerStay2D(Collider2D collidingObject)
+		{
+			if (!_enteredColliders.Contains(collidingObject))
+			{
+				return;
+			}
+
+			bool staying = _stayingGameObjects.Contains(collidingObject.gameObject);
+
+			if (staying && (OnStay != null))
+			{
+				OnStay.Invoke();
+			}
+        
+			if (staying)
+			{
+				return;
+			}
+			TriggerEnter(collidingObject.gameObject);
+		}
+		
+		
+		/// <summary>
+		/// Handles enter collision with 2D triggers
+		/// </summary>
+		/// <param name="collidingObject">Colliding object.</param>
+		protected virtual void OnTriggerExit2D(Collider2D collidingObject)
+		{
+			_enteredColliders.Remove(collidingObject);
+			TriggerExit(collidingObject.gameObject);
+		}
+		
+		
+		/// <summary>
+		/// Triggered when something collides with the button activated zone
+		/// </summary>
+		/// <param name="collider">Something colliding with the water.</param>
+		protected virtual void TriggerEnter(GameObject collider)
+		{    
+           
+			// at this point the object is colliding and authorized, we add it to our list
+			_collidingObjects.Add(collider.gameObject);
+			if (!TestForLastObject(collider))
+			{
+				return;
+			}
+
+			_currentCharacter = collider.gameObject.MMGetComponentNoAlloc<Character>();
+
+
+			_characterRotationalActivation = _currentCharacter?.FindAbility<CharacterRotationalActivation>();
+			if (_characterRotationalActivation != null)
+			{
+				_characterRotationalActivation.InRotationActivatedZone = true;
+				_characterRotationalActivation.RotationActivatedZone = this;
+				_characterRotationalActivation.InButtonAutoActivatedZone = AutoActivation;
+				_characterRotationalActivation.SetTriggerParameter();
+			}
+			EnterFeedback?.PlayFeedbacks(this.transform.position);
+
+
+			// if we're not already showing the prompt and if the zone can be activated, we show it
+			if (ShowPromptWhenColliding)
+			{
+				ShowPrompt();
+			}
+		}
+		
+		
+		/// <summary>
+		/// Triggered when something exits the activation zone
+		/// </summary>
+		/// <param name="collider">Something colliding with the activation zone.</param>
+		protected virtual void TriggerExit(GameObject collider)
+		{
+
+			_collidingObjects.Remove(collider.gameObject);
+			if (!TestForLastObject(collider))
+			{
+				return;
+			}
+
+			_currentCharacter = null;
+
+			_characterRotationalActivation = collider.gameObject.MMGetComponentNoAlloc<Character>()?.FindAbility<CharacterRotationalActivation>();
+			if (_characterRotationalActivation != null)
+			{
+				_characterRotationalActivation.InRotationActivatedZone = false;
+				_characterRotationalActivation.RotationActivatedZone= null;
+				_characterRotationalActivation.InButtonAutoActivatedZone = false;
+				_characterRotationalActivation.InJumpPreventingZone = false;
+			}
+		
+
+			ExitFeedback?.PlayFeedbacks(this.transform.position);
+
+			if ((_rotationPrompt != null) && !AlwaysShowPrompt)
+			{
+				HidePrompt();
+			}
+
+			TriggerExitAction(collider);
+		}
+		
+		
+		/// <summary>
+		/// Tests if the object exiting our zone is the last remaining one
+		/// </summary>
+		/// <param name="collider"></param>
+		/// <returns></returns>
+		protected virtual bool TestForLastObject(GameObject collider)
+		{
+			if (OnlyOneActivationAtOnce)
+			{
+				if (_collidingObjects.Count > 0)
+				{
+					bool lastObject = true;
+					foreach (GameObject obj in _collidingObjects)
+					{
+						if ((obj != null) && (obj != collider))
+						{
+							lastObject = false;
+						}
+					}
+					return lastObject;
+				}
+			}
+			return true;
+		}
+    }


### PR DESCRIPTION
This module implements the measuring and calculation of Rotational Input - in this case using the Right Analog stick on the gamepad, or TFGH on the keyboard (didn't want to overwrite the secondary input).

I use it in our game for triggering "rotate" actions as an alternative interaction to button-mashes.